### PR TITLE
Change to auth method

### DIFF
--- a/join-protocol.md
+++ b/join-protocol.md
@@ -38,7 +38,13 @@ Since authentication tokens are the only means of identifying a site, this token
 
 **3.** Every HTTP request that **A** submits to **B** must contain the token that **B** told **A** to use in HTTP header called 'X-Auth-Token'. For example:
 
-    https://phenomecentral.org/rest/remoteMatcher/mmapi/v1/match?key=854a439d278df4283bf5498ab020336cdc416a7d
+    https://phenomecentral.org/rest/remoteMatcher/mmapi/v1/match
+    
+    POST /rest/remoteMatcher/mmapi/v1/match HTTP/1.1
+	Host: phenomecentral.org
+	Accept: application/json
+	Content-Type: application/json; charset=UTF-8
+	X-Auth-Token: 854a439d278df4283bf5498ab020336cdc416a7d
 
 In this case:
 * `https://phenomecentral.org/rest/remoteMatcher` is the base URL


### PR DESCRIPTION
As discussed in the technical working group (https://groups.google.com/forum/#!topic/matchmaker-exchange-technical/Wf-TwRcAUnc) it would be better to have the auth token in the header of the request as opposed to the query string. It was agreed this should also effect v1, as the v1 document doesn't specify this directly.

I have made this as a pull request to allow others to comment in case it was missed in the google group. (This is how the Decipher implementation will be delivered)
